### PR TITLE
Add single regex address parser, remove input whois formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,3 +141,45 @@ Let's create new parser for TLDs `.jp` and `.co.jp`
 1. Write tests. 
     1. Creating whois fixture `test/whois_co_jp.txt` with valid whois
     2. Write your parser tests in `parser_co_jp_test.go`
+### Single regex for address usage
+1. Set SingleRegexAddress field to true in Registrant field of your parser
+    ```
+       registrantRegex: &RegistrantRegex{
+            SingleRegexAddress: true,
+         },
+    ```
+1. Use regex with group naming:
+    2. For ```Street``` field use ``street`` name
+    2. For ```StreetExt``` field use ``StreetExt`` name
+    2. For ```City``` field use ``city`` name
+    2. For ```PostalCode``` field use ``postalCode`` name
+    2. For ```Province``` field use ``province`` name
+    2. For ```Country``` field use ``country`` name
+    
+    Example:
+    ```
+        (?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat
+    ```
+    Missing groups will set by empty value.
+1. Set Address field with your regex:
+    ```
+        registrantRegex: &RegistrantRegex{
+            SingleRegexAddress: true,
+            Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
+           },
+    ```
+1. Any other address field will be ignored
+    ```
+        registrantRegex: &RegistrantRegex{
+            SingleRegexAddress: true,
+            Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
+            City:               regexp.MustCompile(`City (.*)`), //Will be ignored
+        },
+    ```
+### Input text formatting
+By default parser remove all lines shorten then lineMinLen and trim text.
+
+1. To disable text trim set usefulWhitespaces to true
+    ```
+        usefulWhitespaces: true,
+   ```

--- a/README.md
+++ b/README.md
@@ -141,38 +141,48 @@ Let's create new parser for TLDs `.jp` and `.co.jp`
 1. Write tests. 
     1. Creating whois fixture `test/whois_co_jp.txt` with valid whois
     2. Write your parser tests in `parser_co_jp_test.go`
-### Single regex for address usage
+
+### Single regex for address parsing
+
 1. Set SingleRegexAddress field to true in Registrant field of your parser
+
     ```
        registrantRegex: &RegistrantRegex{
-            SingleRegexAddress: true,
-         },
+           SingleRegexAddress: true,
+       },
     ```
+
 1. Use regex with group naming:
-    2. For ```Street``` field use ``street`` name
-    2. For ```StreetExt``` field use ``StreetExt`` name
-    2. For ```City``` field use ``city`` name
-    2. For ```PostalCode``` field use ``postalCode`` name
-    2. For ```Province``` field use ``province`` name
-    2. For ```Country``` field use ``country`` name
+
+    1. For `Street` field use `street` name
+    1. For `StreetExt` field use `StreetExt` name
+    1. For `City` field use `city` name
+    1. For `PostalCode` field use `postalCode` name
+    1. For `Province` field use `province` name
+    1. For `Country` field use `country` name
     
     Example:
+
     ```
-        (?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat
+    (?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat
     ```
+
     Missing groups will set by empty value.
+
 1. Set Address field with your regex:
+
     ```
-        registrantRegex: &RegistrantRegex{
-            SingleRegexAddress: true,
-            Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
-           },
+    registrantRegex: &RegistrantRegex{
+        SingleRegexAddress: true,
+        Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
+    },
     ```
+
 1. Any other address field will be ignored
     ```
-        registrantRegex: &RegistrantRegex{
-            SingleRegexAddress: true,
-            Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
-            City:               regexp.MustCompile(`City (.*)`), //Will be ignored
-        },
+    registrantRegex: &RegistrantRegex{
+        SingleRegexAddress: true,
+        Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
+        City:               regexp.MustCompile(`City (.*)`), //Will be ignored
+    },
     ```

--- a/README.md
+++ b/README.md
@@ -144,12 +144,12 @@ Let's create new parser for TLDs `.jp` and `.co.jp`
 
 ### Single regex for address parsing
 
-1. Set SingleRegexAddress field to true in Registrant field of your parser
+1. Set `SingleRegexAddress` field to `true` in `registrantRegex` field of your parser:
 
     ```
-       registrantRegex: &RegistrantRegex{
-           SingleRegexAddress: true,
-       },
+    registrantRegex: &RegistrantRegex{
+        SingleRegexAddress: true,
+    },
     ```
 
 1. Use regex with group naming:
@@ -167,9 +167,9 @@ Let's create new parser for TLDs `.jp` and `.co.jp`
     (?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat
     ```
 
-    Missing groups will set by empty value.
+    Here all address regex groups are optional. If any group name is missing, the value ... // todo
 
-1. Set Address field with your regex:
+1. Set the `Address` field regex:
 
     ```
     registrantRegex: &RegistrantRegex{
@@ -178,11 +178,12 @@ Let's create new parser for TLDs `.jp` and `.co.jp`
     },
     ```
 
-1. Any other address field will be ignored
+1. If `SingleRegexAddress` is set to `true`, any other address regexes except `Address` will be ignored:
+
     ```
     registrantRegex: &RegistrantRegex{
         SingleRegexAddress: true,
         Address:            regexp.MustCompile(`(?ms)Registrant(?:.*?Address: *(?P<street>.*?)$.*?)\n *(?P<city>.*?)\n *(?P<postalCode>.*?)\n *(?P<province>.*?)\n *(?P<country>.*?)\n.*?Creat`),
-        City:               regexp.MustCompile(`City (.*)`), //Will be ignored
+        City:               regexp.MustCompile(`City (.*)`), // This regex will be ignored as SingleRegexAddress == true
     },
     ```

--- a/README.md
+++ b/README.md
@@ -176,10 +176,3 @@ Let's create new parser for TLDs `.jp` and `.co.jp`
             City:               regexp.MustCompile(`City (.*)`), //Will be ignored
         },
     ```
-### Input text formatting
-By default parser remove all lines shorten then lineMinLen and trim text.
-
-1. To disable text trim set usefulWhitespaces to true
-    ```
-        usefulWhitespaces: true,
-   ```

--- a/parser.go
+++ b/parser.go
@@ -7,7 +7,6 @@ import (
 
 // Parser structure with registrar and registrant sections
 type Parser struct {
-	lineMinLen        int
 	usefulWhitespaces bool
 	errorRegex        *ParseErrorRegex
 	registrarRegex    *RegistrarRegex
@@ -79,10 +78,6 @@ func (p *Parser) removeShortLines(text string) string {
 			line = textLines[i]
 		} else {
 			line = strings.TrimSpace(textLines[i])
-		}
-
-		if len(line) < p.lineMinLen {
-			continue
 		}
 
 		newLines = append(newLines, line)
@@ -218,7 +213,6 @@ func RegisterParser(zone string, parser *Parser) {
 
 // DefaultParser is used in case if no parser for TLD not found
 var DefaultParser = Parser{
-	lineMinLen: 5,
 	errorRegex: &ParseErrorRegex{
 		NoSuchDomain:     regexp.MustCompile(`^No match for domain "`),
 		RateLimit:        nil,

--- a/parser.go
+++ b/parser.go
@@ -25,8 +25,6 @@ func (p *Parser) Parse(text string) *Record {
 		return record
 	}
 
-	text = p.removeShortLines(text)
-
 	record.Registrar = parseRegistrar(&text, p.registrarRegex)
 	record.Registrant = parseRegistrant(&text, p.registrantRegex)
 	record.Admin = parseRegistrant(&text, p.adminRegex)
@@ -63,22 +61,6 @@ func (p *Parser) getErrCode(text string) ErrCode {
 	}
 
 	return ErrCodeNoError
-}
-
-// removeShortLines trims spaces
-func (p *Parser) removeShortLines(text string) string {
-	var line string
-
-	textLines := strings.Split(text, "\n")
-	newLines := make([]string, 0, len(textLines))
-
-	for i := 0; i < len(textLines); i++ {
-		line = strings.TrimSpace(textLines[i])
-
-		newLines = append(newLines, line)
-	}
-
-	return strings.Join(newLines[:], "\n")
 }
 
 func parseRegistrar(text *string, re *RegistrarRegex) *Registrar {

--- a/parser.go
+++ b/parser.go
@@ -125,12 +125,16 @@ func parseRegistrant(text *string, re *RegistrantRegex) *Registrant {
 	fillIfFound(&registrant.ID, re.ID, text)
 	fillIfFound(&registrant.Name, re.Name, text)
 	fillIfFound(&registrant.Organization, re.Organization, text)
-	fillIfFound(&registrant.Street, re.Street, text)
-	fillIfFound(&registrant.StreetExt, re.StreetExt, text)
-	fillIfFound(&registrant.City, re.City, text)
-	fillIfFound(&registrant.Province, re.Province, text)
-	fillIfFound(&registrant.PostalCode, re.PostalCode, text)
-	fillIfFound(&registrant.Country, re.Country, text)
+	if re.SingleRegexAddress {
+		parseGeographicalAddress(registrant, re.Address, text)
+	} else {
+		fillIfFound(&registrant.Street, re.Street, text)
+		fillIfFound(&registrant.StreetExt, re.StreetExt, text)
+		fillIfFound(&registrant.City, re.City, text)
+		fillIfFound(&registrant.Province, re.Province, text)
+		fillIfFound(&registrant.PostalCode, re.PostalCode, text)
+		fillIfFound(&registrant.Country, re.Country, text)
+	}
 	fillIfFound(&registrant.Phone, re.Phone, text)
 	fillIfFound(&registrant.PhoneExt, re.PhoneExt, text)
 	fillIfFound(&registrant.Fax, re.Fax, text)
@@ -154,6 +158,24 @@ func parserFor(domain string) IParser {
 		}
 	}
 	return &DefaultParser
+}
+
+func parseGeographicalAddress(registrant *Registrant, re *regexp.Regexp, text *string) {
+	if re != nil {
+		regexMatches := re.FindStringSubmatch(*text)
+		resultMap := make(map[string]string)
+		for i, name := range re.SubexpNames() {
+			if i != 0 && name != "" {
+				resultMap[name] = regexMatches[i]
+			}
+		}
+		registrant.Street = resultMap["street"]
+		registrant.City = resultMap["city"]
+		registrant.PostalCode = resultMap["postalCode"]
+		registrant.StreetExt = resultMap["streetExt"]
+		registrant.Province = resultMap["province"]
+		registrant.Country = resultMap["country"]
+	}
 }
 
 func fillIfFound(field *string, re *regexp.Regexp, text *string) {

--- a/parser.go
+++ b/parser.go
@@ -7,13 +7,14 @@ import (
 
 // Parser structure with registrar and registrant sections
 type Parser struct {
-	lineMinLen      int
-	errorRegex      *ParseErrorRegex
-	registrarRegex  *RegistrarRegex
-	registrantRegex *RegistrantRegex
-	adminRegex      *RegistrantRegex
-	techRegex       *RegistrantRegex
-	billRegex       *RegistrantRegex
+	lineMinLen        int
+	usefulWhitespaces bool
+	errorRegex        *ParseErrorRegex
+	registrarRegex    *RegistrarRegex
+	registrantRegex   *RegistrantRegex
+	adminRegex        *RegistrantRegex
+	techRegex         *RegistrantRegex
+	billRegex         *RegistrantRegex
 }
 
 // Parse parses whois text
@@ -66,7 +67,7 @@ func (p *Parser) getErrCode(text string) ErrCode {
 	return ErrCodeNoError
 }
 
-// removeShortLines trims spaces and removes too short lines
+// removeShortLines trims spaces if usefulWhitespaces==false and removes too short lines based on lineMinLen
 func (p *Parser) removeShortLines(text string) string {
 	var line string
 
@@ -74,7 +75,11 @@ func (p *Parser) removeShortLines(text string) string {
 	newLines := make([]string, 0, len(textLines))
 
 	for i := 0; i < len(textLines); i++ {
-		line = strings.TrimSpace(textLines[i])
+		if p.usefulWhitespaces {
+			line = textLines[i]
+		} else {
+			line = strings.TrimSpace(textLines[i])
+		}
 
 		if len(line) < p.lineMinLen {
 			continue

--- a/parser.go
+++ b/parser.go
@@ -7,13 +7,12 @@ import (
 
 // Parser structure with registrar and registrant sections
 type Parser struct {
-	usefulWhitespaces bool
-	errorRegex        *ParseErrorRegex
-	registrarRegex    *RegistrarRegex
-	registrantRegex   *RegistrantRegex
-	adminRegex        *RegistrantRegex
-	techRegex         *RegistrantRegex
-	billRegex         *RegistrantRegex
+	errorRegex      *ParseErrorRegex
+	registrarRegex  *RegistrarRegex
+	registrantRegex *RegistrantRegex
+	adminRegex      *RegistrantRegex
+	techRegex       *RegistrantRegex
+	billRegex       *RegistrantRegex
 }
 
 // Parse parses whois text
@@ -66,7 +65,7 @@ func (p *Parser) getErrCode(text string) ErrCode {
 	return ErrCodeNoError
 }
 
-// removeShortLines trims spaces if usefulWhitespaces==false and removes too short lines based on lineMinLen
+// removeShortLines trims spaces
 func (p *Parser) removeShortLines(text string) string {
 	var line string
 
@@ -74,11 +73,7 @@ func (p *Parser) removeShortLines(text string) string {
 	newLines := make([]string, 0, len(textLines))
 
 	for i := 0; i < len(textLines); i++ {
-		if p.usefulWhitespaces {
-			line = textLines[i]
-		} else {
-			line = strings.TrimSpace(textLines[i])
-		}
+		line = strings.TrimSpace(textLines[i])
 
 		newLines = append(newLines, line)
 	}

--- a/parser_de.go
+++ b/parser_de.go
@@ -5,7 +5,6 @@ import (
 )
 
 var deParser = &Parser{
-	lineMinLen: 5,
 
 	errorRegex: &ParseErrorRegex{
 		NoSuchDomain:     regexp.MustCompile(`Status: free`),

--- a/parser_jp.go
+++ b/parser_jp.go
@@ -5,7 +5,6 @@ import (
 )
 
 var jpParser = &Parser{
-	lineMinLen: 5,
 
 	errorRegex: &ParseErrorRegex{
 		NoSuchDomain:     regexp.MustCompile(`No match!`),

--- a/parser_org.go
+++ b/parser_org.go
@@ -5,7 +5,6 @@ import (
 )
 
 var orgParser = &Parser{
-	lineMinLen: 5,
 
 	errorRegex: &ParseErrorRegex{
 		NoSuchDomain:     regexp.MustCompile(`NOT FOUND`),

--- a/parser_pl.go
+++ b/parser_pl.go
@@ -5,7 +5,6 @@ import (
 )
 
 var plParser = &Parser{
-	lineMinLen: 5,
 
 	errorRegex: &ParseErrorRegex{
 		NoSuchDomain:     regexp.MustCompile(`No information available about domain name`),

--- a/parser_ru.go
+++ b/parser_ru.go
@@ -5,7 +5,6 @@ import (
 )
 
 var ruParser = &Parser{
-	lineMinLen: 5,
 
 	errorRegex: &ParseErrorRegex{
 		NoSuchDomain:     regexp.MustCompile(`No entries found for the selected source`),

--- a/parser_test.go
+++ b/parser_test.go
@@ -19,6 +19,19 @@ func TestFindAndJoinStrings(t *testing.T) {
 	assert.True(t, "asd,Asd" == res || "Asd,asd" == res)
 }
 
+func TestParseGeographicalAddress(t *testing.T) {
+	var text string
+	var re *regexp.Regexp
+	var registrant Registrant
+	text = "Address: Troya, Rim, JustAStreet"
+	re = regexp.MustCompile(`Address:(?: (?P<country>.*?), (?P<city>.*?), (?P<street>.*?))$`)
+	registrant = Registrant{}
+	parseGeographicalAddress(&registrant, re, &text)
+	assert.Equal(t, "Troya", registrant.Country)
+	assert.Equal(t, "Rim", registrant.City)
+	assert.Equal(t, "JustAStreet", registrant.Street)
+}
+
 func TestDefaultParser(t *testing.T) {
 	var fileBytes []byte
 	var err error

--- a/parser_test.go
+++ b/parser_test.go
@@ -35,6 +35,9 @@ func TestDefaultParser(t *testing.T) {
 
 	assert.Contains(t, whoisInfo.Registrar.DomainName, "GOOGLE.COM")
 	assert.Contains(t, whoisInfo.Registrar.DomainName, "google.com")
+	assert.Equal(t, whoisInfo.Registrant.Country, "US")
+	assert.Equal(t, whoisInfo.Registrant.Province, "CA")
+	assert.Equal(t, whoisInfo.Registrant.Organization, "Google LLC")
 
 	assert.Equal(t, "unsigned", whoisInfo.Registrar.DomainDNSSEC)
 	assert.Len(t, whoisInfo.Registrar.DomainStatus, 141)

--- a/registrant.go
+++ b/registrant.go
@@ -22,18 +22,20 @@ type Registrant struct {
 
 // RegistrantRegex struct with regular expressions used to parse Registrant
 type RegistrantRegex struct {
-	ID           *regexp.Regexp
-	Name         *regexp.Regexp
-	Organization *regexp.Regexp
-	Street       *regexp.Regexp
-	StreetExt    *regexp.Regexp
-	City         *regexp.Regexp
-	Province     *regexp.Regexp
-	PostalCode   *regexp.Regexp
-	Country      *regexp.Regexp
-	Phone        *regexp.Regexp
-	PhoneExt     *regexp.Regexp
-	Fax          *regexp.Regexp
-	FaxExt       *regexp.Regexp
-	Email        *regexp.Regexp
+	SingleRegexAddress bool
+	Address            *regexp.Regexp
+	ID                 *regexp.Regexp
+	Name               *regexp.Regexp
+	Organization       *regexp.Regexp
+	Street             *regexp.Regexp
+	StreetExt          *regexp.Regexp
+	City               *regexp.Regexp
+	Province           *regexp.Regexp
+	PostalCode         *regexp.Regexp
+	Country            *regexp.Regexp
+	Phone              *regexp.Regexp
+	PhoneExt           *regexp.Regexp
+	Fax                *regexp.Regexp
+	FaxExt             *regexp.Regexp
+	Email              *regexp.Regexp
 }


### PR DESCRIPTION
- Add feature for parse geographical address with one regex with named group. Needed for some tld whois (e.g "it") 
- Extend readme, extend default parser tests for previous feature
-  Remove input whois text trim. Remove lineMinLen param.