### PR TITLE
Fixed to match from zone with larger string length.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -2,6 +2,7 @@ package whoisparser
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -165,9 +166,18 @@ func Parse(domain string, text string) *Record {
 }
 
 func parserFor(domain string) IParser {
-	for zone, parser := range parsers {
+	zones := make([]string, len(parsers))
+	for zone := range parsers {
+		zones = append(zones, zone)
+	}
+
+	sort.Slice(zones, func(i, j int) bool {
+		return len(zones[i]) > len(zones[j])
+	})
+
+	for _, zone := range zones {
 		if strings.HasSuffix(domain, zone) {
-			return parser
+			return parsers[zone]
 		}
 	}
 	return &DefaultParser

--- a/parser_test.go
+++ b/parser_test.go
@@ -90,6 +90,56 @@ func TestFillGeoAddress(t *testing.T) {
 	assert.Equal(t, "", registrant.Province)
 }
 
+func TestParserForRegisterParserOrderByZoneLengthAsc(t *testing.T) {
+	var (
+		tldPlus2Parser = &DefaultParser
+		tldPlus1Parser = coJpParser
+		tldParser      = jpParser
+	)
+
+	RegisterParser(".ex.co.jp", tldPlus2Parser)
+	RegisterParser(".co.jp", tldPlus1Parser)
+	RegisterParser(".jp", tldParser)
+
+	assert.Equal(t, parserFor("example.ex.co.jp"), tldPlus2Parser)
+	assert.Equal(t, parserFor("example.co.jp"), tldPlus1Parser)
+	assert.Equal(t, parserFor("example.jp"), tldParser)
+
+	assert.NotEqual(t, parserFor("example.co.jp"), tldPlus2Parser)
+	assert.NotEqual(t, parserFor("example.jp"), tldPlus2Parser)
+
+	assert.NotEqual(t, parserFor("example.ex.co.jp"), tldPlus1Parser)
+	assert.NotEqual(t, parserFor("example.jp"), tldPlus1Parser)
+
+	assert.NotEqual(t, parserFor("example.ex.co.jp"), tldParser)
+	assert.NotEqual(t, parserFor("example.co.jp"), tldParser)
+}
+
+func TestParserForRegisterParserOrderByZoneLengthDesc(t *testing.T) {
+	var (
+		tldPlus2Parser = &DefaultParser
+		tldPlus1Parser = coJpParser
+		tldParser      = jpParser
+	)
+
+	RegisterParser(".jp", tldParser)
+	RegisterParser(".co.jp", tldPlus1Parser)
+	RegisterParser(".ex.co.jp", tldPlus2Parser)
+
+	assert.Equal(t, parserFor("example.ex.co.jp"), tldPlus2Parser)
+	assert.Equal(t, parserFor("example.co.jp"), tldPlus1Parser)
+	assert.Equal(t, parserFor("example.jp"), tldParser)
+
+	assert.NotEqual(t, parserFor("example.co.jp"), tldPlus2Parser)
+	assert.NotEqual(t, parserFor("example.jp"), tldPlus2Parser)
+
+	assert.NotEqual(t, parserFor("example.ex.co.jp"), tldPlus1Parser)
+	assert.NotEqual(t, parserFor("example.jp"), tldPlus1Parser)
+
+	assert.NotEqual(t, parserFor("example.ex.co.jp"), tldParser)
+	assert.NotEqual(t, parserFor("example.co.jp"), tldParser)
+}
+
 func TestParseRegistrantNilAddressRegex(t *testing.T) {
 	var text string
 	text = `Registrant Country: UK


### PR DESCRIPTION
Changed parserFor method to match from zone with larger character length.
This change was made to ensure that ".co.jp" is selected instead of the zone name ".jp" if the domain name is "example.co.jp".

Regards.